### PR TITLE
New driver script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ Cargo.lock
 .idea/*
 cmake-build-vanguard/*
 /result
+/.venv

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,9 @@ message(${LLVM_LIBRARY_DIRS})
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED on)
 
+set(CMAKE_CXX_VISIBILITY_PRESET hidden)
+set(CMAKE_VISIBILITY_INLINES_HIDDEN on)
+
 add_subdirectory(lib)  # Use your pass name here.
 # TODO Here: define a bunch of variables in CMAKE that can be used as string substitutes into configure file
 # Pass them in as options in CMake, try to set up variables

--- a/README.md
+++ b/README.md
@@ -18,15 +18,16 @@ can be compiled to LLVM.
 To run Vanguard on a smart contract, you can simply run the following command:
 
 ```bash
-python3 run.py --src_path=<PATH_TO_SMART_CONTRACT> --detector=<NAME_OF_DETECTOR>
+python3 vanguard_driver.py --src_path=<PATH_TO_SMART_CONTRACT> --detector=<NAME_OF_DETECTOR>
 ```
 
-where `<PATH_TO_SMART_CONTRACT>` is the path to the contract to be analyzed, and `<NAME_OF_DETECTOR>` is the name 
-of the detector to be run (e.g., `reentrancy`). To run all available detectors on the contract, use the detector name `all`.
+where `<PATH_TO_SMART_CONTRACT>` is the path to the contract to be analyzed, and
+`<NAME_OF_DETECTOR>` is the name of the detector to be run (e.g., `reentrancy`).
+To run all available detectors on the contract, use the detector name `all`.
 
 As an example, running this command:
 ```bash
-python3 run.py --src_path test/PuppetPool.sol --detector statGen
+python3 vanguard_driver.py --src_path test/PuppetPool.sol --detector statGen
 ```
 should produce the following result:
 ```bash
@@ -43,6 +44,16 @@ Statistics:
 # Basic Blocks: 462
 # Instructions: 3316
 ```
+
+If you need to debug the output of the driver application, you can add the `-o
+<PATH_TO_DIR>` argument to have the driver script dump all of the intermediate
+files in the provided directory. By default, the output dir will be set to a
+temporary file that will be deleted when the driver script exits.
+
+If the output directory is specified, the driver script will not delete the
+output directory by default so that it can cache the intermediate outputs. For
+convenience, the `--clean` argument can be used to delete the output directory
+before running through the pipeline.
 
 ### Vanguard (for running on compiled LLVM bytecode)
 
@@ -61,6 +72,22 @@ and [RustPreprocessor](https://github.com/Veridise/RustPreprocessor).
 Finally, `<LLVM_Bytecode_Files>` is the path to one or more `.bc` file to be analyzed.
 
 ## How to Install
+
+There are three methods that you can use: Nix (preferred), Docker, and build from source.
+
+### Nix
+
+This repository contains a Nix flake that sets up the environment. However,
+because submodules are used, you must add a flag to Nix to build correctly.
+
+To build, use `nix build '.?submodules=1#vanguard`.
+
+To launch a developer shell, use `nix develop '.?submodules=1'`. Once you are in
+the developer shell, you can run the following commands:
+* Generate CMake configuration: `phases=configurePhase genericBuild`
+* Maintain the driver script
+  * Run mypy: `mypy vanguard_driver.py`
+  * Format the driver script: `black vanguard_driver.py && isort --profile black vanguard_driver.py`
 
 ### Docker
 

--- a/flake.nix
+++ b/flake.nix
@@ -50,9 +50,9 @@
 
       default = pkgs.libVanguard.overrideAttrs (attrs: {
         buildInputs = attrs.buildInputs ++ [
-          pkgs.nodejs
-          pkgs.nodePackages.npm
-          pkgs.nodePackages.typescript
+          pkgs.solidity-preprocessor
+          pkgs.solang
+          pkgs.python3Packages.venvShellHook
         ];
         nativeBuildInputs = (attrs.nativeBuildInputs or []) ++ [
           # clang-format, clang-tidy
@@ -64,6 +64,15 @@
 
         cmakeBuildType = "Debug";
         cmakeFlags = ["-DCMAKE_EXPORT_COMPILE_COMMANDS=on"];
+
+        venvDir = "./.venv";
+        postVenvCreation = ''
+          pip3 install --upgrade pip
+          # TODO: create a pyproject.toml
+          pip3 install 'tabulate==0.9.0'
+          # developer stuff
+          pip3 install mypy black isort 'python-lsp-server[all]' pytest
+        '';
 
         shellHook = ''
           # Fix CMAKE_COMPILE_COMMANDS

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,10 @@
         cmakeBuildType = "Debug";
         cmakeFlags = ["-DCMAKE_EXPORT_COMPILE_COMMANDS=on"];
 
+        # Don't inject security hardening & optimization flags for the debug build.
+        # See: https://github.com/NixOS/nixpkgs/issues/18995
+        hardeningDisable = ["all"];
+
         venvDir = "./.venv";
         postVenvCreation = ''
           pip3 install --upgrade pip

--- a/vanguard_driver.py
+++ b/vanguard_driver.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+
+import argparse
+import dataclasses
+import enum
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from collections import defaultdict
+
+# from tabulate import tabulate
+from pathlib import Path
+from typing import Dict, List, Literal, Union
+
+############################
+# Detectors
+############################
+DETECTORS = ["statGen", "fnPrinter", "Reentrancy", "irValidator"]
+
+
+def solidity_summarizer_cmd(sol_file: Path):
+    return ["solidity-summarizer", str(sol_file)]
+
+
+############################
+# Extensions
+############################
+
+
+class Platform(enum.Enum):
+    SOLIDITY = "solidity"
+    RUST = "rust"
+
+
+SRC_FILE_EXTENTIONS = {
+    ".sol": Platform.SOLIDITY,
+    ".rs": Platform.RUST,
+}
+
+
+def get_per_func_info(s: str):
+    patt = re.compile("(Function '([^']*)' [^\n]*)")
+    matches = patt.findall(s)
+
+    return matches
+
+
+@dataclasses.dataclass
+class VanguardDriverOpts:
+    """CLI options for the Vanguard driver."""
+
+    src_path: Path
+    detectors: List[str]
+    create_ir: bool
+    output_dir: Path
+
+    # Whether to "clean" compile
+    clean: bool
+
+
+def preprocess_file(args: VanguardDriverOpts, lang: Platform, ext: str):
+    """Run any instrumentation/preprocessing needed to convert to LLVM."""
+
+    if lang == Platform.SOLIDITY:
+
+        def is_cached(out_path: Path, src_path: Path) -> bool:
+            return (
+                out_path.exists()
+                and out_path.stat().st_mtime >= src_path.stat().st_mtime
+            )
+
+        # hack to prevent solc-typed-ast from writing to the Nix store
+        # TODO: move this to the flake
+        solc_env: Dict[str, str] = {}
+        solc_env.update(os.environ)
+        solc_env["SOL_AST_COMPILER_CACHE"] = "/tmp/solc-typed-ast"
+
+        # Run summarizer and save result to json
+        summarizer_cmd = solidity_summarizer_cmd(args.src_path)
+        summary_name = args.src_path.stem + "_deploy_summary.json"
+        summary_path = args.output_dir / summary_name
+
+        if not is_cached(summary_path, args.src_path):
+            with open(summary_path, "wb") as f:
+                print("Running Solidity summarizer...", end="", flush=True)
+                summary = subprocess.check_output(
+                    summarizer_cmd, stderr=subprocess.DEVNULL, env=solc_env
+                )
+                f.write(summary)
+                print(f"Completed Solidity summarizer, summary at {summary_path}.")
+        else:
+            print(f"Using cached summary at {summary_path}.")
+
+        # Run preprocessor and save result to json
+        preprocessed_name = f"{args.src_path.stem}_instrumented{args.src_path.suffix}"
+        preprocessed_path = args.output_dir / preprocessed_name
+
+        if not is_cached(preprocessed_path, args.src_path):
+            preprocessor_cmd = ["solidity-preprocessor", str(args.src_path)]
+            with open(preprocessed_path, "wb") as f:
+                print("Running Solidity preprocessor...", end="", flush=True)
+                preprocessed = subprocess.check_output(
+                    preprocessor_cmd, stderr=subprocess.DEVNULL, env=solc_env
+                )
+                f.write(preprocessed)
+                print(
+                    "Completed Solidity preprocessor, preprocessed version at {}.".format(
+                        preprocessed_path
+                    )
+                )
+        else:
+            print(f"Using cached preprocessed version at {preprocessed_path}.")
+
+        def mk_solang_cmd(
+            out_type: Literal["llvm-ir", "llvm-bc"], src_path: Path, out_dir: Path
+        ):
+            """Generate commandline command for Solang."""
+            return [
+                "solang",
+                str(src_path),
+                "--target",
+                "ewasm",
+                "--emit",
+                out_type,
+                "-o",
+                str(out_dir),
+            ]
+
+        solang_cmd = mk_solang_cmd("llvm-bc", preprocessed_path, args.output_dir)
+
+        # Run solang
+        print("Running Solang...", end="")
+        subprocess.check_output(solang_cmd, stderr=subprocess.DEVNULL)
+        print(
+            "Completed Solang, compiled files in folder at {}".format(args.output_dir)
+        )
+    elif lang == "rust":
+        raise NotImplementedError
+
+    return summary_path
+
+
+def run_detector(detector: str, summary_path: Path, out_dir: Path) -> Dict[str, str]:
+    """Execute the Vanguard detector program on the .bc files in out_dir."""
+    results = {}
+    for bc_path in out_dir.glob("**/*_deploy.bc"):
+        class_name = bc_path.name.replace("_deploy.bc", "")
+        print("Running Vanguard on class {}...".format(class_name), end="")
+        vanguard_cmd: List[Union[str, Path]] = [
+            "Vanguard",
+            bc_path,
+            "--detectors",
+            detector,
+        ]
+        proc = subprocess.run(
+            vanguard_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        )
+        if proc.returncode != 0:
+            print("Got error from Vanguard!")
+            print(proc.stderr)
+            return results
+
+        print("Completed Vanguard.")
+        results[class_name] = proc.stdout
+
+    return results
+
+
+# def print_results(results):
+#    out = [["Class", "Detector", "Function Flagged by Detector", "Detailed Output"]]
+#    for cls, ress in results.items():
+#        for info in ress:
+#            detector, res = info
+#            parsed_res = get_per_func_info(res)
+#            for note, func in parsed_res:
+#                simple_func = func.split("::")[-1].split("__")[0]
+#                row = [cls, detector, simple_func, note]
+#                out.append(row)
+
+#    print(tabulate(out, tablefmt="grid"))
+
+
+def print_results(results):
+    for cls, ress in results.items():
+        for info in ress:
+            detector, res = info
+            print("--------- {} ---------".format(detector))
+            print(res)
+
+
+def run(args: VanguardDriverOpts):
+    """Run the Vanguard driver application."""
+    # Remove existing outputs
+    if args.output_dir.exists() and args.clean:
+        shutil.rmtree(args.output_dir)
+    args.output_dir.mkdir(exist_ok=True)
+    assert args.output_dir.exists()
+
+    ext = args.src_path.suffix
+    if ext not in SRC_FILE_EXTENTIONS:
+        sys.exit(f"File extension {ext} not recognized!")
+
+    lang = SRC_FILE_EXTENTIONS[ext]
+
+    print(f"----Preprocessing {args.src_path}----")
+    summary_path = preprocess_file(args, lang, ext)
+
+    results = defaultdict(list)
+    for detector in args.detectors:
+        print(f"----Running {args.src_path} with {detector} detector----")
+        detector_results = run_detector(detector, summary_path, args.output_dir)
+        for cls, res in detector_results.items():
+            results[cls].append((detector, res))
+
+    print("----VANGUARD REPORT----")
+    print_results(results)
+
+
+def main():
+    """Application entrypoint."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--src_path",
+        help="path to program to run (default is None)",
+        type=Path,
+        required=True,
+    )
+    parser.add_argument(
+        "--detector",
+        help="choose benchmark to curate (default is None, 'all' will run all detectors)",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--create_ir",
+        help="enables output of ir in addition to bc files",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-o",
+        "--output-dir",
+        type=Path,
+        help="output directory (default is temporary directory)",
+        default=None,
+    )
+    parser.add_argument(
+        "--clean",
+        help="remove the output directory if it exists",
+        action="store_true",
+    )
+    args = parser.parse_args()
+
+    if not args.src_path.exists():
+        sys.exit(f"Source path {args.src_path} does not exist!")
+
+    if args.detector not in DETECTORS and args.detector != "all":
+        sys.exit(
+            f"{args.detector} is not a recognized detector (check DETECTORS at top of run.py)!"
+        )
+
+    if args.output_dir is None:
+        tmpd = tempfile.TemporaryDirectory(args.output_dir)
+        args.output_dir = Path(tmpd.name)
+
+    if args.detector == "all":
+        detectors = DETECTORS
+    else:
+        detectors = [args.detector]
+
+    opts = VanguardDriverOpts(
+        src_path=args.src_path,
+        detectors=detectors,
+        create_ir=args.create_ir,
+        output_dir=args.output_dir,
+        clean=args.clean,
+    )
+    run(opts)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This adds a new Vanguard driver script `vanguard_driver.py` that is a cleaned up and improved copy of `run.py`.

* The new driver script assumes all executables are on `PATH`.
* `run.py` is deprecated and should be removed, but it is left in there to avoid breaking people's workflows for now.
* This will have conflicts with #30.
* Only Solang is supported right now. Rust support has been temporarily disabled since it is complex to set up.